### PR TITLE
Fix hiding indicator when promise has been rejected

### DIFF
--- a/ng2-simple-loading.decorator.ts
+++ b/ng2-simple-loading.decorator.ts
@@ -33,7 +33,7 @@ export function LoadingIndicator(props?: string[]): MethodDecorator {
         });
       } else if (subs.__zone_symbol__state === null) {
         const _interval = setInterval(() => {
-          if (subs.__zone_symbol__state === true) {
+          if (subs.__zone_symbol__state !== null) {
             hideLoading(_sectionElem);
             clearInterval(_interval);
           }


### PR DESCRIPTION
Here are the possible statuses of promise:
[https://github.com/angular/zone.js/blob/master/lib/common/promise.ts#L79](https://github.com/angular/zone.js/blob/master/lib/common/promise.ts#L79)

If promise is rejected then its status will be false or 0, so the changed line will never evaluate to true, thus preventing indicator from hiding.